### PR TITLE
get_targets() improvements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,11 +82,13 @@ fn get_targets(matches: &ArgMatches, default_port: Option<u16>) -> Result<Vec<Ta
             }
             let file = File::open(f.unwrap())?;
             let reader = BufReader::new(file);
-            let mut line_no = 1;
+            let mut line_no = 0;
             let mut targets: Vec<Target> = Vec::new();
 
             for line in reader.lines() {
                 let line = line?;
+
+                line_no += 1;
 
                 if line.is_empty() || line.starts_with('#') {
                     continue;
@@ -100,7 +102,6 @@ fn get_targets(matches: &ArgMatches, default_port: Option<u16>) -> Result<Vec<Ta
                         return Err(anyhow!("Parsing HOST:PORT at line {line_no} failed. {e}"));
                     }
                 }
-                line_no += 1;
             }
             Ok(targets)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ fn get_targets(matches: &ArgMatches, default_port: Option<u16>) -> Result<Vec<Ta
                         targets.push(t)
                     },
                     Err(e) => {
-                        return Err(anyhow!("Parsing HOST:PORT at line {line_no} failed. {e}"));
+                        return Err(anyhow!("Parsing line {line_no} ({line}) failed. {e}"));
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,9 +88,7 @@ fn get_targets(matches: &ArgMatches, default_port: Option<u16>) -> Result<Vec<Ta
             for line in reader.lines() {
                 let line = line?;
 
-                /* ignore comment lines starting with # */
-                let first = line.chars().next().unwrap();
-                if first == '#' {
+                if line.is_empty() || line.starts_with('#') {
                     continue;
                 }
 


### PR DESCRIPTION
Don't panic when the target file contains empty lines, fix the line
number calculation and include the line in error messages.