### PR TITLE
Add report export formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ pqcscan tls-scan -t pq.cloudflareresearch.com:443 -o cloudflare.json
 pqcscan create-report -i gmail.json cloudflare.json -o report.html
 ```
 
+To generate CSV, JSON or XML output for spreadsheet import, asset inventory or
+automation workflows, set the report format explicitly:
+
+```
+pqcscan create-report -i gmail.json cloudflare.json --format csv -o report.csv
+pqcscan create-report -i gmail.json cloudflare.json --format json -o report.json
+pqcscan create-report -i gmail.json cloudflare.json --format xml -o report.xml
+```
+
 You can also create a target list in a file and supply it via `-T`. This works for both `tls-scan` and `ssh-scan`.
 
 ```

--- a/TODO
+++ b/TODO
@@ -11,4 +11,6 @@
       and rewrite the templates that all the elements are built up via pure JS
       instead of generated HTML
 
-- [ ] add some combined JSON/CSV/XML export output on top of the HTML format
+- [x] add some combined JSON/CSV/XML export output on top of the HTML format
+      - [x] CSV report export
+      - [x] JSON/XML report export

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use std::collections::{BTreeSet, HashMap};
 use std::convert::From;
 use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter};
+use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tera::{Context, Tera};
@@ -126,7 +126,30 @@ struct ScanWindow {
     scan_type: ScanType,
 }
 
-fn create_report(output_file: &str, input_files: &Vec<&String>) -> Result<()> {
+#[derive(Clone, Copy)]
+enum ReportFormat {
+    Html,
+    Csv,
+    Json,
+    Xml,
+}
+
+impl From<&str> for ReportFormat {
+    fn from(value: &str) -> Self {
+        match value {
+            "csv" => ReportFormat::Csv,
+            "json" => ReportFormat::Json,
+            "xml" => ReportFormat::Xml,
+            _ => ReportFormat::Html,
+        }
+    }
+}
+
+fn create_report(
+    output_file: &str,
+    input_files: &Vec<&String>,
+    report_format: ReportFormat,
+) -> Result<()> {
     log::debug!("Initializing report data structures");
     let mut tls_map: HashMap<String, Vec<ScanResult>> = HashMap::new();
     let mut ssh_map: HashMap<String, Vec<ScanResult>> = HashMap::new();
@@ -253,6 +276,15 @@ fn create_report(output_file: &str, input_files: &Vec<&String>) -> Result<()> {
         scan_windows: scan_windows,
     };
 
+    match report_format {
+        ReportFormat::Html => render_html_report(output_file, &results),
+        ReportFormat::Csv => write_csv_report(output_file, &results),
+        ReportFormat::Json => write_json_report(output_file, &results),
+        ReportFormat::Xml => write_xml_report(output_file, &results),
+    }
+}
+
+fn render_html_report(output_file: &str, results: &ReportResults) -> Result<()> {
     let templates = [
         "macros.html",
         "template.html",
@@ -281,6 +313,329 @@ fn create_report(output_file: &str, input_files: &Vec<&String>) -> Result<()> {
     tera.render_to("template.html", &ctx, f)?;
     log::info!("HTML report written to {}", output_file);
 
+    Ok(())
+}
+
+fn write_csv_report(output_file: &str, results: &ReportResults) -> Result<()> {
+    log::debug!("Writing CSV report to {}", output_file);
+    let f = File::create(output_file)?;
+    let mut writer = BufWriter::new(f);
+    write_csv_report_to_writer(&mut writer, results)?;
+    writer.flush()?;
+    log::info!("CSV report written to {}", output_file);
+    Ok(())
+}
+
+fn write_json_report(output_file: &str, results: &ReportResults) -> Result<()> {
+    log::debug!("Writing JSON report to {}", output_file);
+    let f = File::create(output_file)?;
+    let mut writer = BufWriter::new(f);
+    serde_json::to_writer_pretty(&mut writer, results)?;
+    writer.write_all(b"\n")?;
+    writer.flush()?;
+    log::info!("JSON report written to {}", output_file);
+    Ok(())
+}
+
+fn write_xml_report(output_file: &str, results: &ReportResults) -> Result<()> {
+    log::debug!("Writing XML report to {}", output_file);
+    let f = File::create(output_file)?;
+    let mut writer = BufWriter::new(f);
+    write_xml_report_to_writer(&mut writer, results)?;
+    writer.flush()?;
+    log::info!("XML report written to {}", output_file);
+    Ok(())
+}
+
+fn write_xml_report_to_writer<W: Write>(writer: &mut W, results: &ReportResults) -> Result<()> {
+    writer.write_all(br#"<?xml version="1.0" encoding="UTF-8"?>"#)?;
+    writer.write_all(b"\n<pqcscan_report>\n")?;
+    writeln!(writer, "  <summary>")?;
+    writeln!(
+        writer,
+        "    <ssh total=\"{}\" success=\"{}\" failed=\"{}\" pqc_supported=\"{}\" />",
+        results.ssh_total_count,
+        results.ssh_success_count,
+        results.ssh_fail_count,
+        results.ssh_pqc_supported_count
+    )?;
+    writeln!(
+        writer,
+        "    <tls total=\"{}\" success=\"{}\" failed=\"{}\" pqc_supported=\"{}\" />",
+        results.tls_total_count,
+        results.tls_success_count,
+        results.tls_fail_count,
+        results.tls_pqc_supported_count
+    )?;
+    writeln!(writer, "  </summary>")?;
+    writeln!(writer, "  <scan_windows>")?;
+    for window in &results.scan_windows {
+        writeln!(
+            writer,
+            "    <scan_window type=\"{}\" start_time=\"{}\" end_time=\"{}\" />",
+            scan_type_name(&window.scan_type),
+            xml_escape(&window.start_time.to_rfc3339()),
+            xml_escape(&window.end_time.to_rfc3339())
+        )?;
+    }
+    writeln!(writer, "  </scan_windows>")?;
+    writeln!(writer, "  <results>")?;
+
+    for host in &results.ssh_sorted_hosts {
+        if let Some(host_results) = results.ssh_results.get(host) {
+            for result in host_results {
+                if let ScanResult::Ssh {
+                    targetspec,
+                    addr,
+                    error,
+                    pqc_supported,
+                    pqc_algos,
+                    nonpqc_algos,
+                } = result
+                {
+                    write_xml_result(
+                        writer,
+                        "ssh",
+                        targetspec,
+                        addr,
+                        error,
+                        *pqc_supported,
+                        pqc_algos,
+                        &None,
+                        nonpqc_algos,
+                    )?;
+                }
+            }
+        }
+    }
+
+    for host in &results.tls_sorted_hosts {
+        if let Some(host_results) = results.tls_results.get(host) {
+            for result in host_results {
+                if let ScanResult::Tls {
+                    targetspec,
+                    addr,
+                    error,
+                    pqc_supported,
+                    pqc_algos,
+                    hybrid_algos,
+                    nonpqc_algos,
+                } = result
+                {
+                    write_xml_result(
+                        writer,
+                        "tls",
+                        targetspec,
+                        addr,
+                        error,
+                        *pqc_supported,
+                        pqc_algos,
+                        hybrid_algos,
+                        nonpqc_algos,
+                    )?;
+                }
+            }
+        }
+    }
+
+    writeln!(writer, "  </results>")?;
+    writeln!(writer, "</pqcscan_report>")?;
+    Ok(())
+}
+
+fn write_xml_result<W: Write>(
+    writer: &mut W,
+    scan_type: &str,
+    targetspec: &Target,
+    addr: &Option<String>,
+    error: &Option<String>,
+    pqc_supported: bool,
+    pqc_algos: &Option<Vec<String>>,
+    hybrid_algos: &Option<Vec<String>>,
+    nonpqc_algos: &Option<Vec<String>>,
+) -> Result<()> {
+    writeln!(writer, "    <result scan_type=\"{}\">", scan_type)?;
+    write_xml_text_element(writer, 6, "host", &targetspec.host)?;
+    write_xml_text_element(writer, 6, "port", &targetspec.port.to_string())?;
+    write_xml_text_element(writer, 6, "address", &addr.clone().unwrap_or_default())?;
+    write_xml_text_element(writer, 6, "status", status(error))?;
+    write_xml_text_element(writer, 6, "pqc_supported", &pqc_supported.to_string())?;
+    write_xml_algorithm_list(writer, 6, "pqc_algorithms", pqc_algos)?;
+    write_xml_algorithm_list(writer, 6, "hybrid_algorithms", hybrid_algos)?;
+    write_xml_algorithm_list(writer, 6, "non_pqc_algorithms", nonpqc_algos)?;
+    write_xml_text_element(writer, 6, "error", &error.clone().unwrap_or_default())?;
+    writeln!(writer, "    </result>")?;
+    Ok(())
+}
+
+fn write_xml_algorithm_list<W: Write>(
+    writer: &mut W,
+    indent: usize,
+    name: &str,
+    algorithms: &Option<Vec<String>>,
+) -> Result<()> {
+    writeln!(writer, "{:indent$}<{}>", "", name, indent = indent)?;
+    if let Some(algorithms) = algorithms {
+        for algorithm in algorithms {
+            write_xml_text_element(writer, indent + 2, "algorithm", algorithm)?;
+        }
+    }
+    writeln!(writer, "{:indent$}</{}>", "", name, indent = indent)?;
+    Ok(())
+}
+
+fn write_xml_text_element<W: Write>(
+    writer: &mut W,
+    indent: usize,
+    name: &str,
+    value: &str,
+) -> Result<()> {
+    writeln!(
+        writer,
+        "{:indent$}<{}>{}</{}>",
+        "",
+        name,
+        xml_escape(value),
+        name,
+        indent = indent
+    )?;
+    Ok(())
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+fn scan_type_name(scan_type: &ScanType) -> &'static str {
+    match scan_type {
+        ScanType::Ssh => "ssh",
+        ScanType::Tls => "tls",
+    }
+}
+
+fn write_csv_report_to_writer<W: Write>(writer: &mut W, results: &ReportResults) -> Result<()> {
+    write_csv_record(
+        writer,
+        &[
+            "scan_type",
+            "host",
+            "port",
+            "address",
+            "status",
+            "pqc_supported",
+            "pqc_algorithms",
+            "hybrid_algorithms",
+            "non_pqc_algorithms",
+            "error",
+        ],
+    )?;
+
+    for host in &results.ssh_sorted_hosts {
+        if let Some(host_results) = results.ssh_results.get(host) {
+            for result in host_results {
+                if let ScanResult::Ssh {
+                    targetspec,
+                    addr,
+                    error,
+                    pqc_supported,
+                    pqc_algos,
+                    nonpqc_algos,
+                } = result
+                {
+                    write_csv_record(
+                        writer,
+                        &[
+                            "ssh".to_string(),
+                            targetspec.host.clone(),
+                            targetspec.port.to_string(),
+                            addr.clone().unwrap_or_default(),
+                            status(error).to_string(),
+                            pqc_supported.to_string(),
+                            join_algorithms(pqc_algos),
+                            String::new(),
+                            join_algorithms(nonpqc_algos),
+                            error.clone().unwrap_or_default(),
+                        ],
+                    )?;
+                }
+            }
+        }
+    }
+
+    for host in &results.tls_sorted_hosts {
+        if let Some(host_results) = results.tls_results.get(host) {
+            for result in host_results {
+                if let ScanResult::Tls {
+                    targetspec,
+                    addr,
+                    error,
+                    pqc_supported,
+                    pqc_algos,
+                    hybrid_algos,
+                    nonpqc_algos,
+                } = result
+                {
+                    write_csv_record(
+                        writer,
+                        &[
+                            "tls".to_string(),
+                            targetspec.host.clone(),
+                            targetspec.port.to_string(),
+                            addr.clone().unwrap_or_default(),
+                            status(error).to_string(),
+                            pqc_supported.to_string(),
+                            join_algorithms(pqc_algos),
+                            join_algorithms(hybrid_algos),
+                            join_algorithms(nonpqc_algos),
+                            error.clone().unwrap_or_default(),
+                        ],
+                    )?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn status(error: &Option<String>) -> &'static str {
+    if error.is_some() {
+        "error"
+    } else {
+        "success"
+    }
+}
+
+fn join_algorithms(algorithms: &Option<Vec<String>>) -> String {
+    algorithms
+        .as_ref()
+        .map(|items| items.join(";"))
+        .unwrap_or_default()
+}
+
+fn write_csv_record<W: Write>(writer: &mut W, fields: &[impl AsRef<str>]) -> Result<()> {
+    for (idx, field) in fields.iter().enumerate() {
+        if idx > 0 {
+            writer.write_all(b",")?;
+        }
+        write_csv_field(writer, field.as_ref())?;
+    }
+    writer.write_all(b"\n")?;
+    Ok(())
+}
+
+fn write_csv_field<W: Write>(writer: &mut W, field: &str) -> Result<()> {
+    if field.chars().any(|c| matches!(c, ',' | '"' | '\n' | '\r')) {
+        writer.write_all(b"\"")?;
+        writer.write_all(field.replace('"', "\"\"").as_bytes())?;
+        writer.write_all(b"\"")?;
+    } else {
+        writer.write_all(field.as_bytes())?;
+    }
     Ok(())
 }
 
@@ -337,7 +692,7 @@ fn main() -> Result<()> {
         )
         .subcommand(
             Command::new("create-report")
-                .about("Convert JSON results to HTML report")
+                .about("Convert JSON results to HTML or CSV report")
                 .next_help_heading("Input")
                 .args(vec![Arg::new("input")
                     .short('i')
@@ -346,7 +701,14 @@ fn main() -> Result<()> {
                     .help("JSON file(s) containing scan results ")
                     .num_args(0..)])
                 .next_help_heading("Output")
-                .args(output_args("HTML", true))
+                .args(output_args("report", true))
+                .arg(
+                    Arg::new("format")
+                        .long("format")
+                        .value_parser(["html", "csv", "json", "xml"])
+                        .default_value("html")
+                        .help("Report output format"),
+                )
                 .disable_help_flag(true)
                 .disable_version_flag(true),
         )
@@ -399,7 +761,9 @@ fn main() -> Result<()> {
             output_json_file = sub_matches.get_one::<String>("output");
         }
         Some(("create-report", sub_matches)) => {
-            log::info!("Creating HTML report from JSON results");
+            let report_format =
+                ReportFormat::from(sub_matches.get_one::<String>("format").unwrap().as_str());
+            log::info!("Creating report from JSON results");
             let input_files: Vec<_> = sub_matches
                 .get_many::<String>("input")
                 .ok_or(anyhow!(
@@ -410,6 +774,7 @@ fn main() -> Result<()> {
             create_report(
                 sub_matches.get_one::<String>("output").unwrap(),
                 &input_files,
+                report_format,
             )?;
             log::info!("Report created successfully");
         }
@@ -445,4 +810,137 @@ fn main() -> Result<()> {
     log::info!("PQCscan finished");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_csv_record_escapes_special_characters() {
+        let mut output = Vec::new();
+
+        write_csv_record(
+            &mut output,
+            &["plain", "with,comma", "with \"quote\"", "with\nnewline", ""],
+        )
+        .unwrap();
+
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "plain,\"with,comma\",\"with \"\"quote\"\"\",\"with\nnewline\",\n"
+        );
+    }
+
+    #[test]
+    fn write_csv_report_includes_ssh_and_tls_rows() {
+        let mut ssh_results = HashMap::new();
+        ssh_results.insert(
+            "ssh.example.com".to_string(),
+            vec![ScanResult::Ssh {
+                targetspec: Target {
+                    host: "ssh.example.com".to_string(),
+                    port: 22,
+                },
+                addr: Some("203.0.113.10:22".to_string()),
+                error: None,
+                pqc_supported: true,
+                pqc_algos: Some(vec!["sntrup761x25519-sha512".to_string()]),
+                nonpqc_algos: Some(vec!["curve25519-sha256".to_string()]),
+            }],
+        );
+
+        let mut tls_results = HashMap::new();
+        tls_results.insert(
+            "tls.example.com".to_string(),
+            vec![ScanResult::Tls {
+                targetspec: Target {
+                    host: "tls.example.com".to_string(),
+                    port: 443,
+                },
+                addr: None,
+                error: Some("timeout, retry later".to_string()),
+                pqc_supported: false,
+                pqc_algos: Some(vec![]),
+                hybrid_algos: Some(vec!["X25519MLKEM768".to_string()]),
+                nonpqc_algos: Some(vec!["x25519".to_string()]),
+            }],
+        );
+
+        let results = ReportResults {
+            tls_results,
+            tls_sorted_hosts: BTreeSet::from(["tls.example.com".to_string()]),
+            tls_success_count: 0,
+            tls_fail_count: 1,
+            tls_pqc_supported_count: 0,
+            tls_total_count: 1,
+            ssh_results,
+            ssh_sorted_hosts: BTreeSet::from(["ssh.example.com".to_string()]),
+            ssh_success_count: 1,
+            ssh_fail_count: 0,
+            ssh_pqc_supported_count: 1,
+            ssh_total_count: 1,
+            scan_windows: vec![],
+        };
+
+        let mut output = Vec::new();
+        write_csv_report_to_writer(&mut output, &results).unwrap();
+
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            concat!(
+                "scan_type,host,port,address,status,pqc_supported,pqc_algorithms,hybrid_algorithms,non_pqc_algorithms,error\n",
+                "ssh,ssh.example.com,22,203.0.113.10:22,success,true,sntrup761x25519-sha512,,curve25519-sha256,\n",
+                "tls,tls.example.com,443,,error,false,,X25519MLKEM768,x25519,\"timeout, retry later\"\n",
+            )
+        );
+    }
+
+    #[test]
+    fn write_xml_report_escapes_values() {
+        let mut ssh_results = HashMap::new();
+        ssh_results.insert(
+            "ssh.example.com".to_string(),
+            vec![ScanResult::Ssh {
+                targetspec: Target {
+                    host: "ssh.example.com".to_string(),
+                    port: 22,
+                },
+                addr: Some("203.0.113.10:22".to_string()),
+                error: Some("bad \"quote\" & <tag>".to_string()),
+                pqc_supported: false,
+                pqc_algos: Some(vec!["sntrup761x25519-sha512".to_string()]),
+                nonpqc_algos: Some(vec!["curve25519-sha256".to_string()]),
+            }],
+        );
+
+        let results = ReportResults {
+            tls_results: HashMap::new(),
+            tls_sorted_hosts: BTreeSet::new(),
+            tls_success_count: 0,
+            tls_fail_count: 0,
+            tls_pqc_supported_count: 0,
+            tls_total_count: 0,
+            ssh_results,
+            ssh_sorted_hosts: BTreeSet::from(["ssh.example.com".to_string()]),
+            ssh_success_count: 0,
+            ssh_fail_count: 1,
+            ssh_pqc_supported_count: 0,
+            ssh_total_count: 1,
+            scan_windows: vec![ScanWindow {
+                start_time: Utc::now(),
+                end_time: Utc::now(),
+                scan_type: ScanType::Ssh,
+            }],
+        };
+
+        let mut output = Vec::new();
+        write_xml_report_to_writer(&mut output, &results).unwrap();
+        let output = String::from_utf8(output).unwrap();
+
+        assert!(output.contains(r#"<ssh total="1" success="0" failed="1" pqc_supported="0" />"#));
+        assert!(output.contains(r#"<result scan_type="ssh">"#));
+        assert!(output.contains("<algorithm>sntrup761x25519-sha512</algorithm>"));
+        assert!(output.contains("<error>bad &quot;quote&quot; &amp; &lt;tag&gt;</error>"));
+    }
 }

--- a/support/templates/tls_results.html
+++ b/support/templates/tls_results.html
@@ -70,14 +70,16 @@
                         <tr>
                             <th width="20%">PQC Algorithms</th>
                             <td>
-                                {% if result['pqc_algos'] and result['pqc_algos'].count > 0 %}
+                                {% if result['pqc_algos'] and result['pqc_algos'] | length > 0 %}
                                     {% for algo in result['pqc_algos'] | sort %}
                                         {{ algo }}{% if not loop.last %}, {% endif %}
                                     {% endfor %}
                                 {% endif %}
-                                {% for algo in result['hybrid_algos'] | sort %}
-                                    {{ algo }}{% if not loop.last %}, {% endif %}
-                                {% endfor %}
+                                {% if result['hybrid_algos'] %}
+                                    {% for algo in result['hybrid_algos'] | sort %}
+                                        {{ algo }}{% if not loop.last %}, {% endif %}
+                                    {% endfor %}
+                                {% endif %}
                             </td>
                           </tr>
                     {% else %}


### PR DESCRIPTION
## Summary
- add `--format csv`, `--format json`, and `--format xml` to `create-report`
- keep HTML as the default report output format
- export combined SSH/TLS scan results for spreadsheet import, asset inventory, and automation workflows
- fix TLS HTML report rendering for PQC algorithm lists by using Tera `length` and guarding optional hybrid algorithms
- document the new report formats and update the TODO status

## Why
The TODO lists combined JSON/CSV/XML export on top of the HTML report. These machine-readable formats make it easier to feed pqcscan results into PQC readiness reviews, spreadsheets, and downstream asset inventory tooling.

While visually validating the default HTML report path, TLS PQC algorithm rendering failed on the template expression `result['pqc_algos'].count`. This patch keeps HTML as the default and ensures that path still renders for PQC-enabled TLS results.

## Validation
- `cargo test`
- `git diff --check README.md TODO src/main.rs support/templates/tls_results.html`
- manually generated CSV, JSON, and XML reports from a sample scan result JSON
- generated an HTML report locally and verified the Summary, SSH Results, TLS Results, and filter checkbox interactions in a browser